### PR TITLE
publish: Add verified_floss subset

### DIFF
--- a/src/cmd_publish.rs
+++ b/src/cmd_publish.rs
@@ -337,16 +337,21 @@ pub fn rewrite_metadata(
 fn list_subsets(storefront_info: &StorefrontInfo) -> Vec<String> {
     let mut subsets = vec![];
 
-    if storefront_info
+    let verified = storefront_info
         .verification
         .as_ref()
-        .map_or(false, |x| x.verified)
-    {
+        .map_or(false, |x| x.verified);
+
+    let floss = storefront_info.is_free_software.map_or(false, |x| x);
+
+    if verified {
         subsets.push("verified".to_string());
     }
-
-    if storefront_info.is_free_software.map_or(false, |x| x) {
-        subsets.push("freesoftware".to_string());
+    if floss {
+        subsets.push("floss".to_string());
+    }
+    if verified && floss {
+        subsets.push("verified_floss".to_string());
     }
 
     subsets
@@ -374,7 +379,7 @@ mod tests {
         };
         let subsets = list_subsets(&storefront_info);
 
-        assert_eq!(vec!["verified", "freesoftware"], subsets);
+        assert_eq!(vec!["verified", "floss", "verified_floss"], subsets);
     }
 
     #[test]

--- a/src/storefront.rs
+++ b/src/storefront.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use serde::Deserialize;
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(default, rename_all = "kebab-case")]
+#[serde(default)]
 pub struct StorefrontInfo {
     pub verification: Option<VerificationInfo>,
     pub pricing: Option<PricingInfo>,


### PR DESCRIPTION
Add a verified_floss subset for apps that are both verified and FLOSS. Note that spelling it with a '-' as 'verified-floss' didn't work, I think because flatpak expects the dash to be used in arch subsets.

Also fixed a bug in the storefront info struct.

Fixes flathub/website#1071 and flathub/website#1072.