### PR TITLE
Add moderation to review hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ All of the hooks are built as the same Rust binary and called using subcommands.
 
 This hook is run *during* the publish job. It fetches information about the app from the backend and edits the
 build's commits to match. It updates appstream data, commit subsets, and token type.
+
+## flathub-hooks review
+
+This is the hook for reviewing a build. It checks with the backend for changes in appstream metadata and requests
+a moderator review if necessary. In the future, it will also run the validation scripts and report any errors.

--- a/src/cmd_publish.rs
+++ b/src/cmd_publish.rs
@@ -18,7 +18,7 @@ use ostree::{
 use crate::{
     config::Config,
     storefront::StorefrontInfo,
-    utils::{app_id_from_ref, mtree_lookup, mtree_lookup_file, Transaction},
+    utils::{app_id_from_ref, mtree_lookup, mtree_lookup_file, retry, Transaction},
 };
 
 #[derive(Args, Debug)]
@@ -42,7 +42,7 @@ impl PublishArgs {
 
             let app_id = app_id_from_ref(&refstring);
 
-            let storefront_info = StorefrontInfo::fetch(&config.backend_url, &app_id)?;
+            let storefront_info = retry(|| StorefrontInfo::fetch(&config.backend_url, &app_id))?;
             if !storefront_infos.contains_key(&app_id) {
                 storefront_infos.insert(app_id.clone(), storefront_info);
             }

--- a/src/cmd_review.rs
+++ b/src/cmd_review.rs
@@ -1,43 +1,164 @@
-use std::error::Error;
+use std::{collections::HashMap, error::Error, io::Read};
 
 use clap::Args;
-use reqwest::blocking::Client;
-use serde::Serialize;
+use elementtree::Element;
+use flate2::read::GzDecoder;
+use log::info;
+use ostree::{
+    gio::{Cancellable, File},
+    prelude::FileExt,
+    Repo,
+};
+use serde::{Deserialize, Serialize};
 
-use crate::config::Config;
+use crate::{
+    config::Config,
+    job_utils::require_review,
+    utils::{app_id_from_ref, arch_from_ref, get_build_id, get_job_id, retry},
+};
 
 #[derive(Args, Debug)]
 pub struct ReviewArgs {}
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(tag = "status", content = "reason")]
-pub enum CheckStatus {
-    ReviewRequired(String),
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "kebab-case")]
-struct ReviewRequestArgs {
-    new_status: CheckStatus,
-}
-
 impl ReviewArgs {
     pub fn run(&self, config: &Config) -> Result<(), Box<dyn Error>> {
-        let client = Client::new();
+        /* Open the build repo at the current directory */
+        let repo = Repo::new(&File::for_path("."));
+        repo.open(Cancellable::NONE)?;
 
-        let job_id: i64 = std::env::var("FLAT_MANAGER_JOB_ID")?.parse()?;
-        client
-            .post(format!(
-                "{}/api/v1/job/{}/check/review",
-                config.flat_manager_url, job_id
-            ))
-            .bearer_auth(&config.flat_manager_token)
-            .json(&ReviewRequestArgs {
-                new_status: CheckStatus::ReviewRequired("".to_string()),
-            })
-            .send()?
-            .error_for_status()?;
+        let refs = repo.list_refs(None, Cancellable::NONE)?;
+        let mut request = ReviewRequest {
+            build_id: get_build_id()?,
+            job_id: get_job_id()?,
+            app_metadata: HashMap::new(),
+        };
+
+        info!("Refs present in build: {:?}", refs.keys());
+
+        for (refstring, checksum) in refs.iter() {
+            /* Upload metadata to the backend to check for changes */
+            if refstring.starts_with("app/") || refstring.starts_with("runtime/") {
+                let arch = arch_from_ref(refstring);
+
+                /* For now, only review the x86_64 upload, since that's the one we show on the website */
+                if arch == "x86_64" {
+                    match get_app_metadata(&repo, refstring, checksum) {
+                        Ok(metadata) => {
+                            request
+                                .app_metadata
+                                .insert(app_id_from_ref(refstring), metadata);
+                        }
+                        Err(e) => {
+                            info!("Failed to get app metadata for {}: {}", refstring, e)
+                        }
+                    }
+                }
+            }
+        }
+
+        submit_review_request(request, config)?;
 
         Ok(())
     }
+}
+
+fn get_app_metadata(
+    repo: &Repo,
+    refstring: &str,
+    checksum: &str,
+) -> Result<ReviewItem, Box<dyn Error>> {
+    let app_id = app_id_from_ref(refstring);
+
+    let root = load_appstream(repo, &app_id, checksum)?;
+    let component = root
+        .find("component")
+        .ok_or("No <component> in appstream")?;
+
+    Ok(ReviewItem {
+        name: component.find("name").map(|f| f.text().to_string()),
+        summary: component.find("summary").map(|f| f.text().to_string()),
+        developer_name: component
+            .find("developer_name")
+            .map(|f| f.text().to_string()),
+        project_license: component
+            .find("project_license")
+            .map(|f| f.text().to_string()),
+        project_group: component
+            .find("project_group")
+            .map(|f| f.text().to_string()),
+        compulsory_for_desktop: component
+            .find("compulsory_for_desktop")
+            .map(|f| f.text().to_string()),
+    })
+}
+
+fn load_appstream(repo: &Repo, app_id: &str, checksum: &str) -> Result<Element, Box<dyn Error>> {
+    let (file, _checksum) = repo.read_commit(checksum, Cancellable::NONE)?;
+
+    let appstream_path = format!("files/share/app-info/xmls/{app_id}.xml.gz");
+    let appstream_file = file.resolve_relative_path(&appstream_path);
+    let (appstream_content, _etag) = appstream_file
+        .load_contents(Cancellable::NONE)
+        .map_err(|e| format!("Failed to load the appstream file at {appstream_path}: {e}"))?;
+
+    let mut s = String::new();
+    GzDecoder::new(&*appstream_content).read_to_string(&mut s)?;
+
+    let root = Element::from_reader(s.as_bytes())
+        .map_err(|e| format!("Failed to parse the appstream file at {appstream_path}: {e}"))?;
+
+    Ok(root)
+}
+
+fn submit_review_request(request: ReviewRequest, config: &Config) -> Result<(), Box<dyn Error>> {
+    // Submit the data to the backend for review
+    let endpoint = format!("{}/moderation/submit_review_request", config.backend_url);
+
+    let convert_err = |e| format!("Failed to contact backend {}: {}", &endpoint, e);
+
+    info!("Submitting appdata for review: {request:?}");
+
+    let response = retry(|| {
+        reqwest::blocking::Client::new()
+            .post(&endpoint)
+            .bearer_auth(&config.flat_manager_token)
+            .json(&request)
+            .send()
+            .map_err(convert_err)?
+            .error_for_status()
+            .map_err(convert_err)?
+            .json::<ReviewRequestResponse>()
+            .map_err(convert_err)
+    })?;
+
+    if response.requires_review {
+        require_review(
+            "Some of the changes in this build require review by a moderator.",
+            config,
+        )?;
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct ReviewItem {
+    name: Option<String>,
+    summary: Option<String>,
+    developer_name: Option<String>,
+    project_license: Option<String>,
+    project_group: Option<String>,
+    compulsory_for_desktop: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReviewRequest {
+    build_id: i64,
+    job_id: i64,
+    app_metadata: HashMap<String, ReviewItem>,
+}
+
+#[derive(Deserialize)]
+struct ReviewRequestResponse {
+    requires_review: bool,
 }

--- a/src/job_utils.rs
+++ b/src/job_utils.rs
@@ -1,0 +1,36 @@
+use std::error::Error;
+
+use reqwest::blocking::Client;
+use serde::Serialize;
+
+use crate::{config::Config, utils::get_job_id};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(tag = "status", content = "reason")]
+pub enum CheckStatus {
+    ReviewRequired(String),
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct ReviewRequestArgs {
+    new_status: CheckStatus,
+}
+
+pub fn require_review(reason: &str, config: &Config) -> Result<(), Box<dyn Error>> {
+    let client = Client::new();
+    client
+        .post(format!(
+            "{}/api/v1/job/{}/check/review",
+            config.flat_manager_url,
+            get_job_id()?
+        ))
+        .bearer_auth(&config.flat_manager_token)
+        .json(&ReviewRequestArgs {
+            new_status: CheckStatus::ReviewRequired(reason.to_string()),
+        })
+        .send()?
+        .error_for_status()?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cmd_publish;
 mod cmd_review;
 mod config;
+mod job_utils;
 mod storefront;
 mod utils;
 

--- a/src/storefront.rs
+++ b/src/storefront.rs
@@ -29,7 +29,7 @@ pub struct PricingInfo {
 }
 
 impl StorefrontInfo {
-    fn fetch_once(backend_url: &str, app_id: &str) -> Result<Self, Box<dyn Error>> {
+    pub fn fetch(backend_url: &str, app_id: &str) -> Result<Self, Box<dyn Error>> {
         let endpoint = format!("{backend_url}/purchases/storefront-info");
 
         let convert_err = |e| format!("Failed to fetch storefront info from {}: {}", &endpoint, e);
@@ -53,27 +53,5 @@ impl StorefrontInfo {
         };
 
         Ok(storefront_info)
-    }
-
-    pub fn fetch(backend_url: &str, app_id: &str) -> Result<Self, Box<dyn Error>> {
-        let mut i = 0;
-
-        const RETRY_COUNT: i32 = 15;
-        const WAIT_TIME: u64 = 1;
-
-        loop {
-            match Self::fetch_once(backend_url, app_id) {
-                Ok(info) => return Ok(info),
-                Err(e) => {
-                    info!("{}", e);
-                    i += 1;
-                    if i > RETRY_COUNT {
-                        return Err(e);
-                    }
-                    info!("Retrying ({i}/{RETRY_COUNT}) in {WAIT_TIME} seconds...");
-                    std::thread::sleep(std::time::Duration::from_secs(WAIT_TIME));
-                }
-            }
-        }
     }
 }

--- a/src/storefront.rs
+++ b/src/storefront.rs
@@ -29,7 +29,7 @@ pub struct PricingInfo {
 }
 
 impl StorefrontInfo {
-    pub fn fetch(backend_url: &str, app_id: &str) -> Result<Self, Box<dyn Error>> {
+    fn fetch_once(backend_url: &str, app_id: &str) -> Result<Self, Box<dyn Error>> {
         let endpoint = format!("{backend_url}/purchases/storefront-info");
 
         let convert_err = |e| format!("Failed to fetch storefront info from {}: {}", &endpoint, e);
@@ -53,5 +53,27 @@ impl StorefrontInfo {
         };
 
         Ok(storefront_info)
+    }
+
+    pub fn fetch(backend_url: &str, app_id: &str) -> Result<Self, Box<dyn Error>> {
+        let mut i = 0;
+
+        const RETRY_COUNT: i32 = 15;
+        const WAIT_TIME: u64 = 1;
+
+        loop {
+            match Self::fetch_once(backend_url, app_id) {
+                Ok(info) => return Ok(info),
+                Err(e) => {
+                    info!("{}", e);
+                    i += 1;
+                    if i > RETRY_COUNT {
+                        return Err(e);
+                    }
+                    info!("Retrying ({i}/{RETRY_COUNT}) in {WAIT_TIME} seconds...");
+                    std::thread::sleep(std::time::Duration::from_secs(WAIT_TIME));
+                }
+            }
+        }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,18 @@ use std::error::Error;
 use log::info;
 use ostree::{gio::Cancellable, glib, glib::GString, MutableTree, Repo};
 
+pub fn get_job_id() -> Result<i64, Box<dyn Error>> {
+    Ok(std::env::var("FLAT_MANAGER_JOB_ID")?.parse()?)
+}
+
+pub fn get_build_id() -> Result<i64, Box<dyn Error>> {
+    Ok(std::env::var("FLAT_MANAGER_BUILD_ID")?.parse()?)
+}
+
+pub fn arch_from_ref(refstring: &str) -> String {
+    refstring.split('/').nth(2).unwrap().to_string()
+}
+
 pub fn app_id_from_ref(refstring: &str) -> String {
     let ref_id = refstring.split('/').nth(1).unwrap().to_string();
     let id_parts: Vec<&str> = ref_id.split('.').collect();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 
+use log::info;
 use ostree::{gio::Cancellable, glib, glib::GString, MutableTree, Repo};
 
 pub fn app_id_from_ref(refstring: &str) -> String {
@@ -64,6 +65,30 @@ impl Drop for Transaction<'_> {
             self.repo
                 .abort_transaction(Cancellable::NONE)
                 .expect("Aborting the transaction should not fail");
+        }
+    }
+}
+
+/// Try the given retry function up to `retry_count + 1` times. The first successful result is returned, or the last error if all attempts failed.
+pub fn retry<T, E: std::fmt::Display, F: Fn() -> Result<T, E>>(f: F) -> Result<T, E> {
+    let mut i = 0;
+
+    let retry_count = 5;
+    let mut wait_time = 1;
+
+    loop {
+        match f() {
+            Ok(info) => return Ok(info),
+            Err(e) => {
+                info!("{}", e);
+                i += 1;
+                if i > retry_count {
+                    return Err(e);
+                }
+                info!("Retrying ({i}/{retry_count}) in {wait_time} seconds...");
+                std::thread::sleep(std::time::Duration::from_secs(wait_time));
+                wait_time *= 2;
+            }
         }
     }
 }


### PR DESCRIPTION
Add functionality to the review hook, which was a placeholder before. It uploads certain appstream keys to the new moderation backend (see https://github.com/flathub/website/pull/1405) and marks the job as needing review if necessary. In the future the review hook will also contain the validation scripts that are currently in buildbot.