### PR TITLE
Fix reading appstream in publish hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,9 +28,12 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arrayref"
@@ -34,6 +46,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -229,6 +256,7 @@ dependencies = [
 name = "flathub-hooks"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "diff",
  "elementtree",
@@ -341,6 +369,12 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "gio"
@@ -742,6 +776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1067,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = { version = "1.0.71", features = ["backtrace"] }
 clap = { version = "4.0.29", features = ["derive"] }
 diff = "0.1.13"
 elementtree = "1.2.3"

--- a/src/cmd_publish.rs
+++ b/src/cmd_publish.rs
@@ -11,14 +11,14 @@ use log::info;
 use ostree::{
     gio::{Cancellable, File},
     glib::VariantDict,
-    prelude::{Cast, InputStreamExt},
+    prelude::Cast,
     MutableTree, Repo,
 };
 
 use crate::{
     config::Config,
     storefront::StorefrontInfo,
-    utils::{app_id_from_ref, mtree_lookup, mtree_lookup_file, Transaction},
+    utils::{app_id_from_ref, mtree_lookup, mtree_lookup_file, read_file_from_repo, Transaction},
 };
 
 #[derive(Args, Debug)]
@@ -127,12 +127,7 @@ pub fn rewrite_appstream_file(
         return Ok(());
     }
 
-    let (appstream_file, fileinfo, _) =
-        repo.load_file(&appstream_file.unwrap(), Cancellable::NONE)?;
-
-    let appstream_content = appstream_file
-        .unwrap()
-        .read_bytes(fileinfo.size().try_into().unwrap(), Cancellable::NONE)?;
+    let appstream_content = read_file_from_repo(repo, &appstream_file.unwrap())?;
 
     let mut s = String::new();
     GzDecoder::new(&*appstream_content).read_to_string(&mut s)?;

--- a/src/cmd_review.rs
+++ b/src/cmd_review.rs
@@ -1,5 +1,4 @@
-use std::error::Error;
-
+use anyhow::Result;
 use clap::Args;
 use reqwest::blocking::Client;
 use serde::Serialize;
@@ -22,7 +21,7 @@ struct ReviewRequestArgs {
 }
 
 impl ReviewArgs {
-    pub fn run(&self, config: &Config) -> Result<(), Box<dyn Error>> {
+    pub fn run(&self, config: &Config) -> Result<()> {
         let client = Client::new();
 
         let job_id: i64 = std::env::var("FLAT_MANAGER_JOB_ID")?.parse()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,10 @@ mod config;
 mod storefront;
 mod utils;
 
-use std::error::Error;
 use std::fs;
 use std::{env, path::PathBuf};
 
+use anyhow::Result;
 use clap::{Parser, Subcommand};
 use cmd_publish::PublishArgs;
 use cmd_review::ReviewArgs;
@@ -28,7 +28,7 @@ enum Command {
     Review(ReviewArgs),
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     // Set up logging, with a default verbosity of "info"
     if env::var("RUST_LOG").is_err() {
         env::set_var("RUST_LOG", "info");

--- a/src/storefront.rs
+++ b/src/storefront.rs
@@ -1,5 +1,4 @@
-use std::error::Error;
-
+use anyhow::{anyhow, Result};
 use log::info;
 use serde::Deserialize;
 
@@ -29,10 +28,10 @@ pub struct PricingInfo {
 }
 
 impl StorefrontInfo {
-    pub fn fetch(backend_url: &str, app_id: &str) -> Result<Self, Box<dyn Error>> {
+    pub fn fetch(backend_url: &str, app_id: &str) -> Result<Self> {
         let endpoint = format!("{backend_url}/purchases/storefront-info");
 
-        let convert_err = |e| format!("Failed to fetch storefront info from {}: {}", &endpoint, e);
+        let convert_err = |e| anyhow!("Failed to fetch storefront info from {}: {}", &endpoint, e);
 
         // Fetch the storefront info
         let response = reqwest::blocking::Client::new()


### PR DESCRIPTION
It sometimes wouldn't read the entire appstream file (should have read the GInputStream docs more carefully...) which would cause the publish hook to fail.

Also, added anyhow to make debugging a little easier--we can run the script with `RUST_BACKTRACE=1` to get error backtraces.