### PR TITLE
Make sure build log URL exists, and add it to appstream

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -1,5 +1,5 @@
 {
     "backend_url": "http://localhost:8000",
     "flat_manager_url": "http://localhost:8080",
-    "flat_manager_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJidWlsZCIsInNjb3BlIjpbInJldmlld2NoZWNrIl0sIm5hbWUiOiJkZWZhdWx0IiwicHJlZml4ZXMiOltdLCJyZXBvcyI6W10sImV4cCI6OTcwNDMyMzQ5OH0.NlGRcgycAqE7_BaHdZz5v7cSedZOqB8V8oO3cG3chNI"
+    "flat_manager_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJidWlsZCIsInNjb3BlIjpbInJldmlld2NoZWNrIiwiYnVpbGQiXSwibmFtZSI6ImRlZmF1bHQiLCJwcmVmaXhlcyI6WyIiXSwicmVwb3MiOlsiIl0sImV4cCI6OTcwNDMyMzQ5OH0.hp1MxjiWLJgD2KA9n_k5B4DmrW5P9R4mZMdHvmEzXLI"
 }

--- a/src/review/diagnostics.rs
+++ b/src/review/diagnostics.rs
@@ -15,21 +15,20 @@ pub struct ValidationDiagnostic {
 #[derive(Debug, Serialize)]
 #[serde(tag = "category", content = "data")]
 pub enum DiagnosticInfo {
-    FailedToLoadAppstream {
-        path: String,
-        error: String,
-    },
+    /// The appstream file is missing or couldn't be read.
+    FailedToLoadAppstream { path: String, error: String },
+    /// There is a problem in one of the appstream files.
     AppstreamValidation {
         path: String,
         stdout: String,
         stderr: String,
     },
-    MissingIcon {
-        appstream_path: String,
-    },
-    NoLocalIcon {
-        appstream_path: String,
-    },
+    /// The app does not have a suitable icon.
+    MissingIcon { appstream_path: String },
+    /// The app has a remote icon listed in appstream, but no icon included in the build.
+    NoLocalIcon { appstream_path: String },
+    /// The app is FOSS, but a URL for the build's CI log was not given or is not a valid URL.
+    MissingBuildLogUrl,
 }
 
 impl ValidationDiagnostic {

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -4,7 +4,7 @@ use ostree::gio::{Cancellable, File};
 use ostree::Repo;
 
 use crate::config::Config;
-use crate::job_utils::{mark_failure, mark_still_pending, require_review};
+use crate::job_utils::{get_build, mark_failure, mark_still_pending, require_review};
 use crate::review::diagnostics::CheckResult;
 use crate::review::moderation::{review_build, ReviewRequestResponse};
 use crate::review::validation::validate_build;
@@ -23,13 +23,15 @@ pub fn do_review(config: &Config) -> Result<()> {
 
     let refs = repo.list_refs(None, Cancellable::NONE)?;
 
+    let build = get_build(config)?;
+
     info!("Refs present in build: {:?}", refs.keys());
 
     let mut result = CheckResult {
         diagnostics: vec![],
     };
 
-    validate_build(&repo, &refs, &mut result)?;
+    validate_build(config, &build, &repo, &refs, &mut result)?;
 
     /* If any errors were found, mark the check as failed */
     if result.diagnostics.iter().any(|d| !d.is_warning) {


### PR DESCRIPTION
For apps that are FOSS (as determined by the backend), make sure a build log URL has been specified during validation, and insert it into appstream in the publish hook.

Depends on #13, https://github.com/flatpak/flat-manager/pull/107, and https://github.com/flathub/website/pull/1585.