### PR TITLE
Don't set check status to PassedWithWarnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,7 @@ pub trait Config: ValidateConfig {
     fn mark_failure(&self, reason: &str, result: &CheckResult) -> Result<()> {
         self.set_check_status(&ReviewRequestArgs {
             new_status: if self.validation_observe_only() {
-                CheckStatus::PassedWithWarnings(reason.to_string())
+                CheckStatus::Pending
             } else {
                 CheckStatus::Failed(reason.to_string())
             },

--- a/src/job_utils.rs
+++ b/src/job_utils.rs
@@ -26,7 +26,6 @@ pub struct BuildRef {
 pub enum CheckStatus {
     ReviewRequired(String),
     Failed(String),
-    PassedWithWarnings(String),
     Pending,
 }
 


### PR DESCRIPTION
flat-manager expects the check to not set itself to passed, since it could later crash with an error code.