### PR TITLE
Remove Thunderbird from linter skiplist

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,15 +13,13 @@ use ostree::{
 };
 
 pub const APP_SUFFIXES: [&str; 3] = ["Sources", "Debug", "Locale"];
-pub const APPID_SKIPLIST: [&str; 9] = [
+pub const APPID_SKIPLIST: [&str; 7] = [
     "net.wz2100.wz2100",
     "org.freedesktop.Platform.ClInfo",
     "org.freedesktop.Platform.GlxInfo",
     "org.freedesktop.Platform.VaInfo",
     "org.freedesktop.Platform.VdpauInfo",
     "org.freedesktop.Platform.VulkanInfo",
-    "org.mozilla.thunderbird",
-    "org.mozilla.Thunderbird",
     "org.mozilla.firefox",
 ];
 


### PR DESCRIPTION
The existing linting errors in the thunderbird metadata have been resolved.  Remove it from the skiplist to prevent future errors from landing in flathub.